### PR TITLE
Remove is_deferred from download_file.

### DIFF
--- a/crates.io/rule.bzl
+++ b/crates.io/rule.bzl
@@ -8,7 +8,6 @@ def _crate_download_impl(ctx: AnalysisContext) -> list[Provider]:
         archive.as_output(),
         ctx.attrs.urls[0],
         sha256 = ctx.attrs.sha256,
-        is_deferrable = True,
     )
 
     output, sub_targets = unarchive(


### PR DESCRIPTION
Is not present on recent versions of Buck2.