### PR TITLE
Disable cron and push triggers of CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,7 @@
 name: Buck2
 
 on:
-  push:
   workflow_dispatch:
-  schedule: [cron: "40 14 * * *"]
 
 permissions:
   contents: read


### PR DESCRIPTION
I don't want this workflow running on the same cadence as my other repos, but it is still useful to run on demand occasionally.