### PR TITLE
Remove `//constraints:false` in favor of `prelude//:none`

### DIFF
--- a/constraints/BUCK
+++ b/constraints/BUCK
@@ -1,10 +1,6 @@
 load(":defs.bzl", "constraint")
 
 constraint(
-    setting = "false",
-)
-
-constraint(
     setting = "sysroot-deps",
     values = [
         # Crate must declare explicit dependencies on standard library. This is

--- a/defs.bzl
+++ b/defs.bzl
@@ -162,7 +162,7 @@ def _target_constraints(crate_root):
         ]
     else:
         target_compatible_with = select({
-            "DEFAULT": ["//constraints:false"],
+            "DEFAULT": ["prelude//:none"],
             "//constraints:compiler": [],
             "//constraints:library": [],
         })

--- a/platforms/exec/BUCK
+++ b/platforms/exec/BUCK
@@ -2,7 +2,7 @@ alias(
     name = "os_lookup",
     actual = "prelude//os_lookup/targets:os_lookup",
     target_compatible_with = select({
-        "DEFAULT": ["//constraints:false"],
+        "DEFAULT": ["prelude//:none"],
         "prelude//os:linux": [],
         "prelude//os:macos": [],
         "prelude//os:windows": [],
@@ -14,7 +14,7 @@ alias(
     name = "http_archive",
     actual = "prelude//http_archive/tools:exec_deps",
     target_compatible_with = select({
-        "DEFAULT": ["//constraints:false"],
+        "DEFAULT": ["prelude//:none"],
         "prelude//os:linux": [],
         "prelude//os:macos": [],
         "prelude//os:windows": [],


### PR DESCRIPTION
`prelude//:none` is the canonical spelling for a constraint that is not enabled in any platform.
https://github.com/facebook/buck2/commit/f1d247d3e1253a98bc2f3948ad88e12723978b9f