### PR TITLE
Remove remainder of 'universe' terminology

### DIFF
--- a/BUCK_TREE
+++ b/BUCK_TREE
@@ -7,7 +7,7 @@ set_cfg_modifiers([])
 
 set_cfg_constructor(
     aliases = struct(
-        # Reindeer universe (//constraints:reindeer-universe)
+        # Workspace (//constraints:workspace)
         compiler = "//constraints:compiler",
         library = "//constraints:library",
         # Bootstrap stage (//constraints:bootstrap-stage)

--- a/constraints/BUCK
+++ b/constraints/BUCK
@@ -13,7 +13,7 @@ constraint(
 )
 
 constraint(
-    setting = "reindeer-universe",
+    setting = "workspace",
     values = [
         # Transitive dependencies of rust/library/.
         "library",

--- a/platforms/defs.bzl
+++ b/platforms/defs.bzl
@@ -67,8 +67,8 @@ platform = rule(
         "transition": attrs.list(attrs.configuration_label(), default = [
             "//constraints:bootstrap-stage",
             "//constraints:opt-level",
-            "//constraints:reindeer-universe",
             "//constraints:sysroot-deps",
+            "//constraints:workspace",
         ]),
     },
     is_configuration_rule = True,

--- a/toolchains/cxx/BUCK
+++ b/toolchains/cxx/BUCK
@@ -5,8 +5,8 @@ configuration_transition(
     name = "prune_cxx_configuration",
     discard_settings = [
         "rust//constraints:bootstrap-stage",
-        "rust//constraints:reindeer-universe",
         "rust//constraints:sysroot-deps",
+        "rust//constraints:workspace",
     ],
     label = "cxx",
 )


### PR DESCRIPTION
Since https://github.com/dtolnay/buck2-rustc-bootstrap/pull/9 there is no longer a "universe" in reindeer.toml. Platform-specific dependencies and platform-specific crate features are determined by platform predicates only.

We still need a separation between a library workspace (rust-lang/rust's `library/Cargo.lock`) and a compiler workspace (rust-lang/rust's top-level `Cargo.lock`).