### PR TITLE
Relax compatibility constraints on the library directory

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -151,14 +151,9 @@ def cxx_bootstrap_library(
 
 def _target_constraints(crate_root):
     if crate_root and crate_root.startswith("rust/library/"):
-        target_compatible_with = [
-            "//constraints:library",
-            "//constraints:build-script=false",
-        ]
+        target_compatible_with = ["//constraints:library"]
     elif crate_root and (crate_root.startswith("rust/compiler/") or crate_root.startswith("rust/src/")):
-        target_compatible_with = [
-            "//constraints:compiler",
-        ]
+        target_compatible_with = ["//constraints:compiler"]
     else:
         target_compatible_with = select({
             "DEFAULT": ["prelude//:none"],


### PR DESCRIPTION
Since Rust 1.89, we are now able to use build scripts in the library directory. For example `std` depends on `compiler_builtins` which has a build script at library/compiler-builtins/compiler-builtins/build.rs.
https://github.com/rust-lang/rust/blob/1.89.0/library/std/Cargo.toml#L21
https://github.com/rust-lang/rust/blob/1.89.0/library/compiler-builtins/compiler-builtins/build.rs