### PR TITLE
Support target_compatible_with override for rust_bootstrap_library

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -51,9 +51,10 @@ def rust_bootstrap_library(
         proc_macro = False,
         rustc_flags = [],
         srcs = [],
+        target_compatible_with = None,
         visibility = None,
         **kwargs):
-    target_compatible_with = _target_constraints(crate_root)
+    target_compatible_with = target_compatible_with or _target_constraints(crate_root)
 
     if name.endswith("-0.0.0"):
         versioned_name = name


### PR DESCRIPTION
This is needed in Rust 1.89.0 for the compiler `rustc_proc_macro` crate, which is a compiler crate despite having source code located in the library directory.