### PR TITLE
Provide output sysroot containing copied rlibs not links

### DIFF
--- a/stage1/defs.bzl
+++ b/stage1/defs.bzl
@@ -90,7 +90,7 @@ def _sysroot_impl(ctx: AnalysisContext) -> list[Provider]:
             path = "lib/rustlib/{}/lib/{}".format(rustc_target_triple, artifact.basename)
             sysroot[path] = artifact
 
-    sysroot = ctx.actions.symlinked_dir("sysroot", sysroot)
+    sysroot = ctx.actions.copied_dir("sysroot", sysroot)
     return [DefaultInfo(default_output = sysroot)]
 
 sysroot = rule(


### PR DESCRIPTION
Usually this is what someone would want when using `buck2 build stage2:sysroot --out`.