### PR TITLE
Drop unneeded deps from rustc-main crate

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -7689,12 +7689,6 @@ rust_bootstrap_binary(
         "rustc_driver": ":rustc_driver-0.0.0",
     },
     visibility = [],
-    deps = [
-        ":rustc_codegen_ssa-0.0.0",
-        ":rustc_driver_impl-0.0.0",
-        ":rustc_smir-0.0.0",
-        ":stable_mir-0.1.0-preview",
-    ],
 )
 
 crate_download(
@@ -8690,6 +8684,12 @@ rust_bootstrap_library(
         ":thin-vec-0.2.14",
         ":tracing-0.1.37",
     ],
+)
+
+rust_bootstrap_alias(
+    name = "rustc_driver_impl",
+    actual = ":rustc_driver_impl-0.0.0",
+    visibility = ["PUBLIC"],
 )
 
 rust_bootstrap_library(

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,7 @@ dependencies = [
  "panic_unwind",
  "proc_macro",
  "rustc-main",
+ "rustc_driver_impl",
  "rustdoc-tool",
  "std",
  "test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ test = { path = "rust/library/test" }
 allocator-api2 = { version = "0.2", default-features = false }
 clippy = { path = "rust/src/tools/clippy", artifact = ["bin"] }
 rustc-main = { path = "rust/compiler/rustc", artifact = ["bin"], features = ["llvm"] }
+rustc_driver_impl = { path = "rust/compiler/rustc_driver_impl" }
 rustdoc-tool = { path = "rust/src/tools/rustdoc", artifact = ["bin"] }
 
 [patch.crates-io]

--- a/fixups/rustc-main/fixups.toml
+++ b/fixups/rustc-main/fixups.toml
@@ -1,2 +1,8 @@
 buildscript.run = false
 linker_flags = ["-Wl,-rpath,$ORIGIN/../lib"]
+omit_deps = [
+    "rustc_codegen_ssa",
+    "rustc_driver_impl",
+    "rustc_smir",
+    "stable_mir",
+]


### PR DESCRIPTION
This is a prerequisite for supporting shared linkage on rustc_driver.so. Otherwise rustc_driver_impl and other crates are linked into both rustc and rustc_driver.