### PR TITLE
Include lib dir when running llvm-config remotely

### DIFF
--- a/fixups/rustc_llvm/defs.bzl
+++ b/fixups/rustc_llvm/defs.bzl
@@ -1,6 +1,8 @@
 def _llvm_config_impl(ctx: AnalysisContext) -> list[Provider]:
     llvm = ctx.attrs.llvm[DefaultInfo].default_outputs[0]
-    llvm_config = llvm.project("bin/llvm-config")
+    llvm_bin = llvm.project("bin")
+    llvm_lib = llvm.project("lib")
+    llvm_config = llvm_bin.project("llvm-config").with_associated_artifacts([llvm_lib])
     return [
         DefaultInfo(default_output = llvm_config),
         RunInfo(llvm_config),


### PR DESCRIPTION
Without this, when we run `llvm-config --libs` remotely, the action only receives the `bin/llvm-config` projected artifact inside `//stage0:ci_llvm`, not the lib directory, and will fail:

```console
Action failed: rust//fixups/rustc_llvm:linker-flags (llvm_config)
Remote command returned non-zero exit code 1
Remote action digest: `efaf1917c568d8ee06e532454868a65ab498cfdf431ec63f3e2ed6516d2e9bec:141`
stdout:
stderr:
llvm-config: error: component libraries and shared library
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMDemangle.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMSupport.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMTableGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMTargetParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMBinaryFormat.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMBitstreamReader.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMRemarks.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMCore.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMFuzzerCLI.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMBitReader.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMMC.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMIRReader.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMMCParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMTextAPI.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMObject.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMDebugInfoDWARF.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMDebugInfoCodeView.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMDebugInfoMSF.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMDebugInfoPDB.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMDebugInfoBTF.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMSymbolize.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMProfileData.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAnalysis.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMBitWriter.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMTransformUtils.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAggressiveInstCombine.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMInstCombine.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMScalarOpts.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMFuzzMutate.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMFileCheck.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMInterfaceStub.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMIRPrinter.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMCGData.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMCodeGenTypes.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMObjCARCOpts.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMTarget.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMCodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMSelectionDAG.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAsmPrinter.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMMIRParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMGlobalISel.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMDWARFLinker.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMDWARFLinkerClassic.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMDWARFLinkerParallel.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMExtensions.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMFrontendAtomic.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMFrontendDriver.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMFrontendHLSL.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMFrontendOpenACC.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMFrontendOffloading.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMFrontendOpenMP.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMInstrumentation.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMLinker.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMSandboxIR.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMVectorize.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMipo.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMCoroutines.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMCFGuard.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMHipStdPar.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMPasses.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMLTO.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMMCDisassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMMCA.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMObjCopy.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMObjectYAML.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMOption.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMDebugInfoGSYM.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMDebugInfoLogicalView.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMDWP.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMOrcShared.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMOrcTargetProcess.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMRuntimeDyld.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMExecutionEngine.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMInterpreter.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMJITLink.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMMCJIT.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMWindowsDriver.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMOrcJIT.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMOrcDebugging.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAArch64Info.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAArch64Utils.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAArch64Desc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAArch64CodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAArch64AsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAArch64Disassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAMDGPUInfo.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAMDGPUUtils.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAMDGPUDesc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAMDGPUCodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAMDGPUAsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAMDGPUDisassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAMDGPUTargetMCA.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMARMInfo.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMARMUtils.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMARMDesc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMARMCodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMARMAsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMARMDisassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMBPFInfo.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMBPFDesc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMBPFCodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMBPFAsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMBPFDisassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMHexagonInfo.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMHexagonDesc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMHexagonAsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMHexagonCodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMHexagonDisassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMLoongArchInfo.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMLoongArchDesc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMLoongArchCodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMLoongArchAsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMLoongArchDisassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMMSP430Info.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMMSP430Desc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMMSP430CodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMMSP430AsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMMSP430Disassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMMipsInfo.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMMipsDesc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMMipsCodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMMipsAsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMMipsDisassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMNVPTXInfo.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMNVPTXDesc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMNVPTXCodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMPowerPCInfo.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMPowerPCDesc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMPowerPCCodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMPowerPCAsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMPowerPCDisassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMRISCVInfo.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMRISCVDesc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMRISCVCodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMRISCVAsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMRISCVDisassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMRISCVTargetMCA.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMSparcInfo.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMSparcDesc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMSparcCodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMSparcAsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMSparcDisassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMSystemZInfo.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMSystemZDesc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMSystemZCodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMSystemZAsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMSystemZDisassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMWebAssemblyInfo.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMWebAssemblyDesc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMWebAssemblyUtils.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMWebAssemblyCodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMWebAssemblyAsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMWebAssemblyDisassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMX86Info.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMX86Desc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMX86CodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMX86AsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMX86Disassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMX86TargetMCA.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAVRInfo.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAVRDesc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAVRCodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAVRAsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMAVRDisassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMM68kInfo.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMM68kDesc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMM68kCodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMM68kAsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMM68kDisassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMCSKYInfo.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMCSKYDesc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMCSKYCodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMCSKYAsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMCSKYDisassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMXtensaInfo.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMXtensaDesc.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMXtensaCodeGen.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMXtensaAsmParser.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMXtensaDisassembler.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMLineEditor.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMCoverage.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMTextAPIBinaryReader.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMTelemetry.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMDlltoolDriver.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMLibDriver.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMXRay.a
llvm-config: error: missing: /buildbuddy-execroot/buck-out/v2/gen/rust/1098f4d9b0a4e986/stage0/__ci_llvm__/ci-llvm/lib/libLLVMWindowsManifest.a

BUILD FAILED
Failed to build 'rust//fixups/rustc_llvm:linker-flags (cfg:<empty>#5b68b3d1f7809094)'
```