### PR TITLE
Fix more associated artifacts for projections

### DIFF
--- a/stage0/defs.bzl
+++ b/stage0/defs.bzl
@@ -175,7 +175,7 @@ def _stage0_executable_impl(ctx: AnalysisContext) -> list[Provider]:
             ],
             category = "overlay",
         )
-        command = overlay.project("bin").project(ctx.label.name)
+        command = overlay.project("bin").project(ctx.label.name).with_associated_artifacts([overlay])
     else:
         command = cmd_args(
             ctx.attrs._wrapper[RunInfo],

--- a/stage1/defs.bzl
+++ b/stage1/defs.bzl
@@ -32,7 +32,7 @@ def _rust_tool_impl(ctx: AnalysisContext) -> list[Provider]:
         },
     )
 
-    tool = dist.project(bin_path)
+    tool = dist.project(bin_path).with_associated_artifacts([dist])
 
     return [
         DefaultInfo(


### PR DESCRIPTION
Needed for the same reason as #33 when using Remote Execution.

```console
Action failed: prelude//rust/tools:rustc_cfg (rustc_cfg)
Remote command returned non-zero exit code 127
Remote action digest: `bc6d73d18f101087c5c3dc9fb5ab5f1bf85419c3f91f914131e9efd2f8fb3eb7:141`
stdout:
stderr:
buck-out/v2/gen/rust/4613bb47f78f03c2/stage1/__rustc__/toolchain/bin/rustc: error while loading shared libraries: libLLVM.so.20.1-rust-1.89.0-beta: cannot open shared object file: No such file or directory
```