### PR TITLE
Ignore `expect(unused_crate_dependencies)` in rustc-main

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -7688,6 +7688,7 @@ rust_bootstrap_binary(
     named_deps = {
         "rustc_driver": ":rustc_driver-0.0.0",
     },
+    rustc_flags = ["-Zcrate-attr=allow(unfulfilled_lint_expectations)"],
     visibility = [],
 )
 

--- a/fixups/rustc-main/fixups.toml
+++ b/fixups/rustc-main/fixups.toml
@@ -1,4 +1,5 @@
 buildscript.run = false
+rustc_flags = ["-Zcrate-attr=allow(unfulfilled_lint_expectations)"]
 linker_flags = ["-Wl,-rpath,$ORIGIN/../lib"]
 omit_deps = [
     "rustc_codegen_ssa",


### PR DESCRIPTION
Since #29, compiling the rustc-main crate produces a warning.

```console
warning: this lint expectation is unfulfilled
 --> rust/compiler/rustc/src/main.rs:4:11
  |
4 | #![expect(unused_crate_dependencies)]
  |           ^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unfulfilled_lint_expectations)]` on by default
```