### PR TITLE
Remove allocator-api2 workaround

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -4156,7 +4156,6 @@ rust_bootstrap_library(
         "//constraints:library": ["-Zforce-unstable-if-unmarked"],
     }),
     visibility = [],
-    deps = ["//allocator:allocator-api2"],
 )
 
 crate_download(

--- a/allocator/BUCK
+++ b/allocator/BUCK
@@ -25,13 +25,3 @@ rust_library(
         "//:std",
     ],
 )
-
-alias(
-    name = "allocator-api2",
-    actual = select({
-        "//constraints:library": None,
-        "//constraints:compiler": "//:allocator-api2",
-    }),
-    default_target_platform = "//platforms/stage1:library",
-    visibility = ["//:"],
-)

--- a/fixups/hashbrown/fixups.toml
+++ b/fixups/hashbrown/fixups.toml
@@ -1,8 +1,3 @@
-# Hashbrown does not really depend on allocator-api2 but `cargo metadata` is
-# claiming that it is, likely because of https://github.com/rust-lang/cargo/issues/10801
-omit_deps = ["allocator_api2"]
-extra_deps = ["//allocator:allocator-api2"]
-
 [[rustc_flags_select]]
 "//constraints:compiler" = []
 "//constraints:library" = ["-Zforce-unstable-if-unmarked"]


### PR DESCRIPTION
Unneeded since https://github.com/dtolnay/buck2-rustc-bootstrap/pull/9, as the new Reindeer resolver is no longer reliant on the bad information from `cargo metadata`.