### PR TITLE
Set static preferred linkage for C++ libraries

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -10129,7 +10129,6 @@ cxx_bootstrap_library(
         "rust/compiler/rustc_llvm/llvm-wrapper/SuppressLLVMWarnings.h",
     ],
     compiler_flags = ["--config=$(location //fixups/rustc_llvm:cxx-flags)"],
-    preferred_linkage = "static",
     preprocessor_flags = [
         "-I$(location //stage0:ci_llvm)/include",
         "--config=$(location //fixups/rustc_llvm:preprocessor-flags)",

--- a/defs.bzl
+++ b/defs.bzl
@@ -139,6 +139,7 @@ def cxx_bootstrap_library(
         name = "{}-compile".format(name),
         compatible_with = compatible_with,
         deps = deps + extra_deps,
+        preferred_linkage = "static",
         **kwargs
     )
 

--- a/fixups/rustc_llvm/fixups.toml
+++ b/fixups/rustc_llvm/fixups.toml
@@ -13,4 +13,3 @@ preprocessor_flags = [
     "--config=$(location //fixups/rustc_llvm:preprocessor-flags)",
 ]
 deps = ["//fixups/rustc_llvm:llvm"]
-preferred_linkage = "static"


### PR DESCRIPTION
For example librustc_driver.so should not depend dynamically on libpsm and libblake3. We already set static linkage by default for Rust libraries here, but those 2 crates contain some C++ that got propagated as a dylib.

https://github.com/dtolnay/buck2-rustc-bootstrap/blob/e546acecb42a344e7a9e535b7c52623d7ea53d83/defs.bzl#L112

**Before:**

`buck2 build :rustc_driver[shared] --show-simple-output | xargs readelf --dynamic`

```console
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [lib_blake3-1.8.2-simd_x86_unix-compile.so]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libLLVM.so.20.1-rust-1.89.0-beta]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [lib_psm-0.1.26-psm_s-linux-x86_64-compile.so]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
```

**After:**

```console
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libLLVM.so.20.1-rust-1.89.0-beta]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
```

This more closely matches the linkage of librustc_driver.so from the official dist.

`readelf --dynamic .rustup/toolchains/1.89.0-x86_64-unknown-linux-gnu/lib/librustc_driver-d160d0a70631e302.so`

```console
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libLLVM.so.20.1-rust-1.89.0-stable]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [librt.so.1]
```