### PR TITLE
Make dockerNetwork=off configurable in remote execution properties

### DIFF
--- a/remote_execution/config.bzl
+++ b/remote_execution/config.bzl
@@ -1,3 +1,15 @@
+# It is strongly recommend to set the following in .buckconfig.local for faster
+# runner startup time:
+#
+#     [remote_execution_properties]
+#     dockerNetwork = off
+#
+_buckconfig_remote_execution_properties = {
+    prop: read_config("remote_execution_properties", prop)
+    for prop in ["dockerNetwork"]
+    if read_config("remote_execution_properties", prop)
+}
+
 def executor_config(configuration: ConfigurationInfo) -> CommandExecutorConfig:
     use_windows_path_separators = False
     for value in configuration.constraints.values():
@@ -9,9 +21,8 @@ def executor_config(configuration: ConfigurationInfo) -> CommandExecutorConfig:
             local_enabled = True,
             remote_enabled = True,
             use_limited_hybrid = True,
-            remote_execution_properties = {
+            remote_execution_properties = _buckconfig_remote_execution_properties | {
                 "OSFamily": "Linux",
-                "dockerNetwork": "off",
                 "container-image": "docker://docker.io/dtolnay/buck2-rustc-bootstrap:latest",
             },
             remote_execution_use_case = "buck2-rustc-bootstrap",


### PR DESCRIPTION
According to https://www.buildbuddy.io/docs/rbe-platforms, `dockerNetwork=off` is **strongly recommended** by BuildBuddy.

> `dockerNetwork`: determines which network mode should be used. For `sandbox` isolation, this determines whether the network is enabled or not. Available options are `off` and `bridge`. The default is `bridge`, but we strongly recommend setting this to `off` for faster runner startup time.

This setting works great with BuildBuddy. However, I found that with `dockerNetwork=off`, remote execution with NativeLink is broken. Actions get stuck in `re_queued` state.