### PR TITLE
Add script for troubleshooting RE container

### DIFF
--- a/troubleshoot/BUCK
+++ b/troubleshoot/BUCK
@@ -1,0 +1,6 @@
+load(":defs.bzl", "troubleshoot")
+
+troubleshoot(
+    name = "troubleshoot",
+    script = "troubleshoot.sh",
+)

--- a/troubleshoot/defs.bzl
+++ b/troubleshoot/defs.bzl
@@ -1,0 +1,15 @@
+def _troubleshoot_impl(ctx: AnalysisContext) -> list[Provider]:
+    out = ctx.actions.declare_output("out")
+    ctx.actions.run(
+        ctx.attrs.script,
+        env = {"OUT": out.as_output()},
+        category = "script",
+    )
+    return [DefaultInfo(default_output = out)]
+
+troubleshoot = rule(
+    impl = _troubleshoot_impl,
+    attrs = {
+        "script": attrs.source(),
+    },
+)

--- a/troubleshoot/troubleshoot.sh
+++ b/troubleshoot/troubleshoot.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+pwd >> $OUT
+ls /usr/bin >> $OUT
+echo "$PATH" >> $OUT


### PR DESCRIPTION
NativeLink is randomly failing some actions with an error like the following. The same actions worked fine in BuildBuddy with the same Docker container.

```console
Action failed: rust//:crc32fast-1.5.0-build-script-build (rustc link [pic])
Remote command returned non-zero exit code 1
Remote action digest: `4b04356368fa2a05a02525e91b485abb5349eeedf555196bf0fb1237c9849d1d:141`
stdout:
stderr:
error: linking with `buck-out/v2/gen/rust/e12edaf63f2b7211/__crc32fast-1.5.0-build-script-build__/linker_wrapper.sh` failed: exit status: 127
  |
  = note:  "buck-out/v2/gen/rust/e12edaf63f2b7211/__crc32fast-1.5.0-build-script-build__/linker_wrapper.sh" "-m64" "/tmp/rustcGYQ54d/symbols.o" "<2 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,libcfg_if-*,liblibc-*,liballoc-*,librustc_std_workspace_core-*,libcore-*,libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/tmp/rustcGYQ54d/raw-dylibs" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "buck-out/v2/gen/rust/e12edaf63f2b7211/__crc32fast-1.5.0-build-script-build__/build_script_build" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-nodefaultlibs" "-Wl,--undefined-version" "@buck-out/v2/gen/rust/e12edaf63f2b7211/__crc32fast-1.5.0-build-script-build__/XIPL/__build_script_build-link_linker_args.txt"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: env: 'bash': No such file or directory
```

```console
Action failed: rust//:object-0.37.3-build-script-build (rustc link [pic])
Remote command returned non-zero exit code 1
Remote action digest: `6fa21a1975bcf5ce8ad242bb8e7e7d2c7254822c209dc59166de4516c1db92ab:141`
stdout:
stderr:
error: linking with `buck-out/v2/gen/rust/a713e9241f4e5d45/__object-0.37.3-build-script-build__/linker_wrapper.sh` failed: exit status: 127
  |
  = note:  "buck-out/v2/gen/rust/a713e9241f4e5d45/__object-0.37.3-build-script-build__/linker_wrapper.sh" "-m64" "/tmp/rustcBDOQ5T/symbols.o" "<2 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,libcfg_if-*,liblibc-*,liballoc-*,librustc_std_workspace_core-*,libcore-*,libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/tmp/rustcBDOQ5T/raw-dylibs" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "buck-out/v2/gen/rust/a713e9241f4e5d45/__object-0.37.3-build-script-build__/build_script_build" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-nodefaultlibs" "-Wl,--undefined-version" "@buck-out/v2/gen/rust/a713e9241f4e5d45/__object-0.37.3-build-script-build__/XIPL/__build_script_build-link_linker_args.txt"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: buck-out/v2/gen/rust/a713e9241f4e5d45/__object-0.37.3-build-script-build__/linker_wrapper.sh: line 3: clang++: command not found
```