### PR TITLE
Expand lib dir symlink into a directory of symlinks

### DIFF
--- a/stage0/BUCK
+++ b/stage0/BUCK
@@ -94,4 +94,5 @@ ci_llvm(
 python_bootstrap_binary(
     name = "frob",
     main = "frob.py",
+    visibility = ["PUBLIC"],
 )

--- a/stage0/frob.py
+++ b/stage0/frob.py
@@ -37,6 +37,13 @@ if __name__ == "__main__":
         elif instruction == "--cp":
             source, dest = next(argv), next(argv)
             shutil.copy2(parse(source), parse(dest))
+        elif instruction == "--elaborate":
+            link = parse(next(argv))
+            target = link.readlink()
+            link.unlink()
+            link.mkdir()
+            for f in (link.parent / target).iterdir():
+                (link / f.name).symlink_to(".." / target / f.name)
         elif instruction == "--exec":
             exe = parse(next(argv))
             env = os.environ.copy()

--- a/stage1/defs.bzl
+++ b/stage1/defs.bzl
@@ -30,6 +30,7 @@ def _rust_tool_impl(ctx: AnalysisContext) -> list[Provider]:
             ["--mkdir", "{dist}/bin"],
             ["--cp", "{exe}", "{dist}/bin/" + ctx.label.name],
             ["--symlink", "{llvm}/lib", "{dist}/lib"],
+            ["--elaborate", "{dist}/lib"],
         ],
         category = "dist",
     )

--- a/stage1/defs.bzl
+++ b/stage1/defs.bzl
@@ -16,23 +16,25 @@ SYSROOT_CRATES = [
 ]
 
 def _rust_tool_impl(ctx: AnalysisContext) -> list[Provider]:
-    llvm = ctx.actions.symlinked_dir(
-        "llvm",
-        {
-            "lib": ctx.attrs.llvm[DefaultInfo].default_outputs[0].project("lib"),
-        },
+    llvm = ctx.attrs.llvm[DefaultInfo].default_outputs[0]
+    exe = ctx.attrs.exe[DefaultInfo].default_outputs[0]
+
+    dist = ctx.actions.declare_output("toolchain", dir = True)
+    ctx.actions.run(
+        [
+            ctx.attrs._frob[RunInfo],
+            cmd_args(llvm, format = "llvm={}", relative_to = dist),
+            cmd_args(exe, format = "exe={}"),
+            cmd_args(dist.as_output(), format = "dist={}"),
+            ["--mkdir", "{dist}"],
+            ["--mkdir", "{dist}/bin"],
+            ["--cp", "{exe}", "{dist}/bin/" + ctx.label.name],
+            ["--symlink", "{llvm}/lib", "{dist}/lib"],
+        ],
+        category = "dist",
     )
 
-    bin_path = "bin/{}".format(ctx.label.name)
-    dist = ctx.actions.copied_dir(
-        "toolchain",
-        {
-            bin_path: ctx.attrs.exe[DefaultInfo].default_outputs[0],
-            "lib": llvm.project("lib"),
-        },
-    )
-
-    tool = dist.project(bin_path).with_associated_artifacts([dist])
+    tool = dist.project("bin").project(ctx.label.name).with_associated_artifacts([dist])
 
     return [
         DefaultInfo(
@@ -50,6 +52,7 @@ rust_tool = rule(
     attrs = {
         "exe": attrs.dep(),
         "llvm": attrs.dep(),
+        "_frob": attrs.default_only(attrs.exec_dep(providers = [RunInfo], default = "//stage0:frob")),
     },
     supports_incoming_transition = True,
 )


### PR DESCRIPTION
Treating the entire `lib` directory as a symlink to `//stage0:ci_llvm`'s lib directory is not going to work if we need more than just libLLVM.so in the lib directory. For example librustc_driver.so in an upcoming PR.