### PR TITLE
Reproduce configuration mangled by cfg_constructor_post_constraint_analysis

### DIFF
--- a/repro/BUCK
+++ b/repro/BUCK
@@ -1,0 +1,21 @@
+load(":defs.bzl", "target")
+
+platform(
+    name = "platform",
+    constraint_values = [
+        "prelude//cpu/constraints:riscv64",
+    ],
+)
+
+configured_alias(
+    name = "repro",
+    actual = ":repro_impl",
+    platform = ":platform",
+)
+
+target(
+    name = "repro_impl",
+    target_compatible_with = [
+        "prelude//cpu/constraints:riscv64",
+    ],
+)

--- a/repro/defs.bzl
+++ b/repro/defs.bzl
@@ -1,0 +1,1 @@
+target = rule(impl = lambda ctx: [DefaultInfo()], attrs = {})


### PR DESCRIPTION
```console
$ buck2 cquery //repro:repro_impl --target-universe //repro:repro
rust//repro:repro_impl (rust//repro:platform#0ee08af45ab565c8)

$ buck2 cquery //repro:repro_impl --target-platforms //repro:platform
rust//repro:repro_impl (cfg:<empty>#c054be65b1d578a8)

$ buck2 audit configurations 'rust//repro:platform#0ee08af45ab565c8' 'cfg:<empty>#c054be65b1d578a8'
rust//repro:platform#0ee08af45ab565c8:
  prelude//cpu/constraints:riscv64                            (prelude//cpu/constraints:cpu)
cfg:<empty>#c054be65b1d578a8:
  prelude//cpu/constraints:riscv64                            (prelude//cpu/constraints:cpu)
```