### PR TITLE
Compute all platform naming from constraints

### DIFF
--- a/BUCK_TREE
+++ b/BUCK_TREE
@@ -1,7 +1,8 @@
-load("@prelude//cfg/modifier:cfg_constructor.bzl", "cfg_constructor_post_constraint_analysis", "cfg_constructor_pre_constraint_analysis")
+load("@prelude//cfg/modifier:cfg_constructor.bzl", "cfg_constructor_pre_constraint_analysis")
 load("@prelude//cfg/modifier:common.bzl", "MODIFIER_METADATA_KEY")
 load("@prelude//cfg/modifier/set_cfg_modifiers.bzl", "set_cfg_modifiers")
 load("@prelude//rust:cargo_package.bzl", "set_reindeer_platforms")
+load("//platforms:name.bzl", "cfg_constructor_post_constraint_analysis")
 
 set_cfg_modifiers([])
 

--- a/constraints/defs.bzl
+++ b/constraints/defs.bzl
@@ -1,3 +1,5 @@
+load("//platforms:name.bzl", "platform_info_label")
+
 def _unified_constraint_impl(ctx: AnalysisContext) -> list[Provider]:
     label = ctx.label.raw_target()
     setting = ConstraintSettingInfo(label = label)
@@ -38,8 +40,6 @@ def constraint(setting, values = []):
         )
 
 def _configuration_transition_impl(ctx: AnalysisContext) -> list[Provider]:
-    label = ctx.attrs.label or ctx.label.name
-
     if ctx.attrs.add_fallback_settings:
         fallback_constraints = ctx.attrs.add_fallback_settings[PlatformInfo].configuration.constraints
     else:
@@ -60,7 +60,7 @@ def _configuration_transition_impl(ctx: AnalysisContext) -> list[Provider]:
                 constraints[setting] = value
 
         return PlatformInfo(
-            label = label,
+            label = platform_info_label(constraints),
             configuration = ConfigurationInfo(
                 constraints = constraints,
                 values = platform.configuration.values,
@@ -78,7 +78,6 @@ configuration_transition = rule(
         "add_fallback_settings": attrs.option(attrs.dep(providers = [PlatformInfo]), default = None),
         "discard_settings": attrs.option(attrs.list(attrs.dep(providers = [ConstraintSettingInfo])), default = None),
         "keep_settings": attrs.option(attrs.list(attrs.dep(providers = [ConstraintSettingInfo])), default = None),
-        "label": attrs.option(attrs.string(), default = None),
     },
     is_configuration_rule = True,
 )

--- a/platforms/defs.bzl
+++ b/platforms/defs.bzl
@@ -1,4 +1,5 @@
 load("//remote_execution:config.bzl", "executor_config")
+load(":name.bzl", "platform_info_label")
 
 def _platform_impl(ctx: AnalysisContext) -> list[Provider]:
     platform_label = ctx.label.raw_target()
@@ -28,7 +29,7 @@ def _platform_impl(ctx: AnalysisContext) -> list[Provider]:
                 constraints[setting] = value
 
         return PlatformInfo(
-            label = str(platform_label),
+            label = platform_info_label(constraints),
             configuration = ConfigurationInfo(
                 constraints = constraints,
                 values = platform.configuration.values,
@@ -38,7 +39,7 @@ def _platform_impl(ctx: AnalysisContext) -> list[Provider]:
     return [
         DefaultInfo(),
         PlatformInfo(
-            label = str(platform_label),
+            label = platform_info_label(configuration.constraints),
             configuration = configuration,
         ),
         TransitionInfo(impl = transition_impl),

--- a/platforms/name.bzl
+++ b/platforms/name.bzl
@@ -1,3 +1,8 @@
+load(
+    "@prelude//cfg/modifier:cfg_constructor.bzl",
+    "PostConstraintAnalysisParams",
+    prelude_post_constraint_analysis = "cfg_constructor_post_constraint_analysis",
+)
 load("@prelude//platforms:defs.bzl", "host_configuration")
 
 def platform_info_label(constraints: dict[TargetLabel, ConstraintValueInfo]) -> str:
@@ -33,3 +38,13 @@ def platform_info_label(constraints: dict[TargetLabel, ConstraintValueInfo]) -> 
         return "null"
 
     return "cfg"
+
+def cfg_constructor_post_constraint_analysis(
+        *,
+        refs: dict[str, ProviderCollection],
+        params: PostConstraintAnalysisParams) -> PlatformInfo:
+    platform = prelude_post_constraint_analysis(refs = refs, params = params)
+    return PlatformInfo(
+        label = platform_info_label(platform.configuration.constraints),
+        configuration = platform.configuration,
+    )

--- a/platforms/name.bzl
+++ b/platforms/name.bzl
@@ -1,0 +1,35 @@
+load("@prelude//platforms:defs.bzl", "host_configuration")
+
+def platform_info_label(constraints: dict[TargetLabel, ConstraintValueInfo]) -> str:
+    settings = {}
+    for constraint in constraints.values():
+        settings[str(constraint.setting.label)] = constraint.label.name
+
+    stage = settings.get("rust//constraints:bootstrap-stage")
+    workspace = settings.get("rust//constraints:workspace")
+    build_script = settings.get("rust//constraints:build-script")
+    os = settings.get("prelude//os/constraints:os")
+    cpu = settings.get("prelude//cpu/constraints:cpu")
+
+    host_os = host_configuration.os.split(":")[1]
+    host_cpu = host_configuration.cpu.split(":")[1]
+
+    if not stage and not workspace and not build_script and os == host_os and cpu == host_cpu:
+        return "rust//platforms:host"
+
+    if stage and workspace and build_script:
+        label = "rust//platforms/{}:{}".format(stage, workspace)
+        if build_script == "build-script=true":
+            label += "-build-script"
+        return label
+
+    if os and cpu:
+        return "{}-{}".format(os, cpu)
+
+    if os or cpu:
+        return os or cpu
+
+    if len(settings) == 0:
+        return "null"
+
+    return "cfg"

--- a/stage0/BUCK
+++ b/stage0/BUCK
@@ -16,7 +16,6 @@ configuration_transition(
         "prelude//cpu/constraints:cpu",
         "prelude//os/constraints:os",
     ],
-    label = "stage0",
 )
 
 stage0_download(

--- a/toolchains/cxx/BUCK
+++ b/toolchains/cxx/BUCK
@@ -8,7 +8,6 @@ configuration_transition(
         "rust//constraints:build-script",
         "rust//constraints:workspace",
     ],
-    label = "cxx",
 )
 
 prebuilt_cxx_library(


### PR DESCRIPTION
This works around the configuration divergence noticed in https://github.com/dtolnay/buck2-rustc-bootstrap/pull/50 where different ways of referring to what should have been the same platform were ending up with distinct platform hashes and buck-out paths.

**Before:**

```console
$ buck2 cquery //:std --target-universe stage1:std
rust//:std (rust//platforms/stage1:library#3e4a316d0bd6add0)

$ buck2 cquery //:std --target-platforms //platforms/stage1:library
rust//:std (cfg:<empty>#557975a32fe1902c)
```

**After:**

```console
$ buck2 cquery //:std --target-universe stage1:std
rust//:std (rust//platforms/stage1:library#3e4a316d0bd6add0)

$ buck2 cquery //:std --target-platforms //platforms/stage1:library
rust//:std (rust//platforms/stage1:library#3e4a316d0bd6add0)
```