### PR TITLE
Split up rustc vs clang target triples

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -87,7 +87,7 @@ def rust_bootstrap_library(
             "//constraints:stage2": "(buckified stage2)",
         })
         extra_env["CFG_COMPILER_HOST_TRIPLE"] = "$(target_triple)"
-        extra_deps.append("toolchains//target:target_triple")
+        extra_deps.append("toolchains//target:rustc_target_triple")
     else:
         default_target_platform = None
         extra_rustc_flags.append("--cap-lints=allow")

--- a/toolchains/cxx.bzl
+++ b/toolchains/cxx.bzl
@@ -110,7 +110,7 @@ cxx_toolchain = rule(
     attrs = {
         "c_flags": attrs.list(attrs.arg(), default = []),
         "cxx_flags": attrs.list(attrs.arg(), default = []),
-        "target_triple": attrs.default_only(attrs.dep(providers = [TargetTriple], default = "//target:target_triple")),
+        "target_triple": attrs.default_only(attrs.dep(providers = [TargetTriple], default = "//target:clang_target_triple")),
         "_cxx_tools_info": attrs.exec_dep(providers = [CxxToolsInfo], default = "prelude//toolchains/msvc:msvc_tools" if host_info().os.is_windows else "prelude//toolchains/cxx/clang:path_clang_tools"),
         "_internal_tools": attrs.default_only(attrs.exec_dep(providers = [CxxInternalTools], default = "prelude//cxx/tools:internal_tools")),
         "_target_os_type": attrs.default_only(attrs.dep(providers = [OsLookup], default = "prelude//os_lookup/targets:os_lookup")),

--- a/toolchains/rust.bzl
+++ b/toolchains/rust.bzl
@@ -61,7 +61,7 @@ rust_toolchain = rule(
             attrs.option(attrs.dep()),
             attrs.dict(key = attrs.string(), value = attrs.dep()),
         ),
-        "target_triple": attrs.default_only(attrs.dep(providers = [TargetTriple], default = "//target:target_triple")),
+        "target_triple": attrs.default_only(attrs.dep(providers = [TargetTriple], default = "//target:rustc_target_triple")),
     },
     is_toolchain_rule = True,
 )

--- a/toolchains/target/BUCK
+++ b/toolchains/target/BUCK
@@ -1,13 +1,36 @@
 load(":target_triple.bzl", "target_triple")
 
 target_triple(
-    name = "target_triple",
+    name = "rustc_target_triple",
     incoming_transition = "rust//stage0:stage0_configuration",
     value = select({
         "prelude//os:linux": select({
             "prelude//cpu:arm64": "aarch64-unknown-linux-gnu",
             "prelude//cpu:riscv64": "riscv64gc-unknown-linux-gnu",
             "prelude//cpu:x86_64": "x86_64-unknown-linux-gnu",
+        }),
+        "prelude//os:macos": select({
+            "prelude//cpu:arm64": "aarch64-apple-darwin",
+            "prelude//cpu:x86_64": "x86_64-apple-darwin",
+        }),
+        "prelude//os:windows": select({
+            "prelude//cpu:arm64": "aarch64-pc-windows-msvc",
+            "prelude//cpu:x86_64": "x86_64-pc-windows-msvc",
+        }),
+    }),
+    visibility = ["PUBLIC"],
+)
+
+target_triple(
+    name = "clang_target_triple",
+    incoming_transition = "rust//stage0:stage0_configuration",
+    value = select({
+        # Different from rustc triple: `unknown` -> `pc`
+        "prelude//os:linux": select({
+            "prelude//cpu:arm64": "aarch64-pc-linux-gnu",
+            # Different from rustc triple: no `gc`
+            "prelude//cpu:riscv64": "riscv64-pc-linux-gnu",
+            "prelude//cpu:x86_64": "x86_64-pc-linux-gnu",
         }),
         "prelude//os:macos": select({
             "prelude//cpu:arm64": "aarch64-apple-darwin",


### PR DESCRIPTION
Rustc takes different target triples than Clang. For example `riscv64gc-unknown-linux-gnu` vs `riscv64-pc-linux-gnu` for the same platform.