### PR TITLE
Optimize link-type for remote execution

### DIFF
--- a/fixups/rustc_llvm/BUCK
+++ b/fixups/rustc_llvm/BUCK
@@ -2,6 +2,7 @@ load(
     ":defs.bzl",
     "llvm_config",
     "llvm_cxx_flags",
+    "llvm_link_type",
     "llvm_linker_flags",
     "llvm_preprocessor_flags",
     "llvm_rustc_flags",
@@ -16,6 +17,11 @@ configured_alias(
     name = "host-llvm-config",
     actual = ":llvm-config",
     platform = "//platforms:host",
+)
+
+llvm_link_type(
+    name = "target-llvm-link-type",
+    llvm = "//stage0:ci_llvm",
 )
 
 llvm_rustc_flags(
@@ -39,7 +45,7 @@ llvm_preprocessor_flags(
 llvm_linker_flags(
     name = "linker-flags",
     host_llvm_config = ":host-llvm-config",
-    target_llvm = "//stage0:ci_llvm",
+    target_llvm_link_type = ":target-llvm-link-type",
 )
 
 prebuilt_cxx_library(

--- a/fixups/rustc_llvm/BUCK
+++ b/fixups/rustc_llvm/BUCK
@@ -2,7 +2,6 @@ load(
     ":defs.bzl",
     "llvm_config",
     "llvm_cxx_flags",
-    "llvm_link_type",
     "llvm_linker_flags",
     "llvm_preprocessor_flags",
     "llvm_rustc_flags",
@@ -17,11 +16,6 @@ configured_alias(
     name = "host-llvm-config",
     actual = ":llvm-config",
     platform = "//platforms:host",
-)
-
-llvm_link_type(
-    name = "target-llvm-link-type",
-    llvm = "//stage0:ci_llvm",
 )
 
 llvm_rustc_flags(
@@ -45,7 +39,7 @@ llvm_preprocessor_flags(
 llvm_linker_flags(
     name = "linker-flags",
     host_llvm_config = ":host-llvm-config",
-    target_llvm_link_type = ":target-llvm-link-type",
+    target_llvm = "//stage0:ci_llvm",
 )
 
 prebuilt_cxx_library(

--- a/fixups/rustc_llvm/defs.bzl
+++ b/fixups/rustc_llvm/defs.bzl
@@ -24,27 +24,6 @@ def _rustc_cfg_llvm_component_impl(
     actions.write(output, "".join(cfg))
     return []
 
-def _llvm_link_type_impl(ctx: AnalysisContext) -> list[Provider]:
-    link_type = ctx.actions.declare_output("link-type.txt")
-    ctx.actions.run(
-        [
-            ctx.attrs._frob[RunInfo],
-            cmd_args(ctx.attrs.llvm[DefaultInfo].default_outputs[0], format = "source={}"),
-            cmd_args(link_type.as_output(), format = "dest={}"),
-            ["--cp", "{source}/link-type.txt", "{dest}"],
-        ],
-        category = "cp",
-    )
-    return [DefaultInfo(default_output = link_type)]
-
-llvm_link_type = rule(
-    impl = _llvm_link_type_impl,
-    attrs = {
-        "llvm": attrs.dep(),
-        "_frob": attrs.default_only(attrs.exec_dep(providers = [RunInfo], default = "//stage0:frob")),
-    },
-)
-
 _rustc_cfg_llvm_component = dynamic_actions(
     impl = _rustc_cfg_llvm_component_impl,
     attrs = {
@@ -232,11 +211,22 @@ _linker_flags = dynamic_actions(
 )
 
 def _llvm_linker_flags_impl(ctx: AnalysisContext) -> list[Provider]:
+    link_type = ctx.actions.declare_output("link-type.txt")
+    ctx.actions.run(
+        [
+            ctx.attrs._frob[RunInfo],
+            cmd_args(ctx.attrs.target_llvm[DefaultInfo].default_outputs[0], format = "source={}"),
+            cmd_args(link_type.as_output(), format = "dest={}"),
+            ["--cp", "{source}/link-type.txt", "{dest}"],
+        ],
+        category = "link_type",
+    )
+
     llvm_config_libs = ctx.actions.declare_output("libs")
     ctx.actions.dynamic_output_new(
         _run_llvm_config_for_linker_flags(
             host_llvm_config = ctx.attrs.host_llvm_config[RunInfo],
-            link_type = ctx.attrs.target_llvm_link_type[DefaultInfo].default_outputs[0],
+            link_type = link_type,
             output = llvm_config_libs.as_output(),
             redirect_stdout = ctx.attrs._redirect_stdout[RunInfo],
         ),
@@ -256,7 +246,8 @@ llvm_linker_flags = rule(
     impl = _llvm_linker_flags_impl,
     attrs = {
         "host_llvm_config": attrs.dep(providers = [RunInfo]),
-        "target_llvm_link_type": attrs.dep(),
+        "target_llvm": attrs.dep(),
+        "_frob": attrs.default_only(attrs.exec_dep(providers = [RunInfo], default = "//stage0:frob")),
         "_redirect_stdout": attrs.default_only(attrs.exec_dep(providers = [RunInfo], default = "prelude//rust/tools:redirect_stdout")),
     },
 )

--- a/fixups/rustc_llvm/defs.bzl
+++ b/fixups/rustc_llvm/defs.bzl
@@ -211,11 +211,16 @@ _linker_flags = dynamic_actions(
 )
 
 def _llvm_linker_flags_impl(ctx: AnalysisContext) -> list[Provider]:
+    link_type = ctx.actions.copy_file(
+        "link-type.txt",
+        ctx.attrs.target_llvm[DefaultInfo].default_outputs[0].project("link-type.txt"),
+    )
+
     llvm_config_libs = ctx.actions.declare_output("libs")
     ctx.actions.dynamic_output_new(
         _run_llvm_config_for_linker_flags(
             host_llvm_config = ctx.attrs.host_llvm_config[RunInfo],
-            link_type = ctx.attrs.target_llvm[DefaultInfo].default_outputs[0].project("link-type.txt"),
+            link_type = link_type,
             output = llvm_config_libs.as_output(),
             redirect_stdout = ctx.attrs._redirect_stdout[RunInfo],
         ),


### PR DESCRIPTION
`buck2 build fixups/rustc_llvm:linker-flags?windows && buck2 clean && time buck2 build fixups/rustc_llvm:linker-flags?windows`

With the original code, this takes 28 seconds of which almost all is spent in "**rust//fixups/rustc_llvm:linker-flags -- dynamic analysis \[local_materialize_inputs\]**". It materializes the entire target LLVM artifact as a prerequisite for evaluating `_run_llvm_config_for_linker_flags`. This is not fixed by simply doing `copy_file` which could be a Buck bug.

With the new code it takes 1.4 seconds and only link-type.txt is materialized, not the rest of LLVM.