### PR TITLE
Add :dist targets that overlay rustc + sysroot + libllvm

### DIFF
--- a/stage0/defs.bzl
+++ b/stage0/defs.bzl
@@ -3,6 +3,7 @@ load("@prelude//http_archive:unarchive.bzl", "unarchive")
 load("@prelude//os_lookup:defs.bzl", "OsLookup")
 load("@prelude//rust:targets.bzl", "targets")
 load("@prelude//utils:cmd_script.bzl", "cmd_script")
+load("//stage1:defs.bzl", "RustDistInfo")
 
 Stage0Info = provider(
     fields = {
@@ -352,7 +353,10 @@ def _ci_llvm_impl(ctx: AnalysisContext) -> list[Provider]:
         sub_targets = {},
     )
 
-    return [DefaultInfo(default_output = contents)]
+    return [
+        DefaultInfo(default_output = contents),
+        RustDistInfo(artifacts = {"lib": contents.project("lib")}),
+    ]
 
 ci_llvm = rule(
     impl = _ci_llvm_impl,

--- a/stage0/frob.py
+++ b/stage0/frob.py
@@ -44,6 +44,13 @@ if __name__ == "__main__":
                 (link / f.name).symlink_to(".." / target / f.name)
         elif instruction == "--mkdir":
             parse(next(argv)).mkdir()
+        elif instruction == "--overlay":
+            source, dest = parse(next(argv)), parse(next(argv))
+            if source.is_dir():
+                shutil.copytree(source, dest, symlinks=True, dirs_exist_ok=True)
+            else:
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, dest)
         elif instruction == "--read":
             name, path = next(argv).split("=", 1)
             with open(parse(path)) as f:

--- a/stage1/BUCK
+++ b/stage1/BUCK
@@ -1,5 +1,5 @@
 load("//constraints:defs.bzl", "transition_alias")
-load(":defs.bzl", "SYSROOT_CRATES", "rust_tool", "sysroot")
+load(":defs.bzl", "SYSROOT_CRATES", "rust_dist", "rust_tool", "sysroot")
 
 [
     transition_alias(
@@ -47,4 +47,13 @@ sysroot(
     incoming_transition = "//platforms/stage1:library",
     visibility = ["toolchains//:rust"],
     deps = [":std"],
+)
+
+rust_dist(
+    name = "dist",
+    deps = [
+        ":rustc",
+        ":sysroot",
+        "//stage0:ci_llvm",
+    ],
 )

--- a/stage2/BUCK
+++ b/stage2/BUCK
@@ -1,5 +1,5 @@
 load("//constraints:defs.bzl", "transition_alias")
-load("//stage1:defs.bzl", "SYSROOT_CRATES", "rust_tool", "sysroot")
+load("//stage1:defs.bzl", "SYSROOT_CRATES", "rust_dist", "rust_tool", "sysroot")
 
 [
     transition_alias(
@@ -47,4 +47,13 @@ sysroot(
     incoming_transition = "//platforms/stage2:library",
     visibility = ["toolchains//:rust"],
     deps = [":std"],
+)
+
+rust_dist(
+    name = "dist",
+    deps = [
+        ":rustc",
+        ":sysroot",
+        "//stage0:ci_llvm",
+    ],
 )


### PR DESCRIPTION
This is going to be used in the implementation of x.py's `--keep-stage` workflow.